### PR TITLE
mockgun: implement in for multy entity (RDEV-8558)

### DIFF
--- a/package.py
+++ b/package.py
@@ -1,17 +1,14 @@
 name = "shotgun_api3"
 
 shotgunSoftwareVersion = "3.0.32"
-rodeoVersion = "1.2.0"
+rodeoVersion = "1.3.0"
 version = "-rdo-".join([shotgunSoftwareVersion, rodeoVersion])
 
-authors = [
-    "shotgundev@rodeofx.com"
-]
+authors = ["shotgundev@rodeofx.com"]
 
-description = \
-    """Fork of the python api of shotgun."""
+description = """Fork of the python api of shotgun."""
 
-requires = ['python-2.4+<3',]
+requires = ['python-2.4+<3']
 
 variants = []
 

--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -609,6 +609,10 @@ class Shotgun(object):
                 if rval is None:
                     return len(lval) != 0
                 return rval["id"] not in (sub_lval["id"] for sub_lval in lval)
+            elif operator == 'in':
+                if rval is None:
+                    return len(lval) != 0
+                return all(element['id'] in (sub_lval['id'] for sub_lval in lval) for element in rval)
 
         raise ShotgunError("The %s operator is not supported on the %s type" % (operator, field_type))
 

--- a/tests/test_mockgun.py
+++ b/tests/test_mockgun.py
@@ -320,6 +320,16 @@ class TestMultiEntityFieldComparison(TestBaseWithExceptionTests):
         for item in items:
             self.assertTrue(len(item["users"]) > 0)
 
+    def test_find_in(self):
+        """Ensures comparison with multi-entity using in."""
+        user = self._mockgun.find_one('HumanUser', [['login', 'is', 'user1']])
+        project = self._mockgun.create(
+            "Project", {"name": "unittest", "users": [self._user1, self._user2]}
+        )
+
+        result = self._mockgun.find('Project', [['users', 'in', user]])
+        self.assertEqual(project['id'], result[0]['id'])
+
 
 class TestFilterOperator(TestBaseWithExceptionTests):
     """


### PR DESCRIPTION
**Purpose of the PR / What does this do?**
Allow doing `in` comparison for multi entities
 
**Potential risks of this change, if any.**

Low risks
 
**Relationship with other PRs (with links!)**
     * blocks: https://bitbucket.org/rodeofx/rdo_shot_description/pull-requests/1