### PR TITLE
mockgun: add support of durations (RDEV-7666)

### DIFF
--- a/package.py
+++ b/package.py
@@ -1,7 +1,7 @@
 name = "shotgun_api3"
 
 shotgunSoftwareVersion = "3.0.32"
-rodeoVersion = "1.3.0"
+rodeoVersion = "1.4.0"
 version = "-rdo-".join([shotgunSoftwareVersion, rodeoVersion])
 
 authors = ["shotgundev@rodeofx.com"]

--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -466,6 +466,7 @@ class Shotgun(object):
                                    "serializable": dict,
                                    "date": basestring,
                                    "date_time": datetime.datetime,
+                                   "duration": int,
                                    "list": basestring,
                                    "status_list": basestring,
                                    "url": dict}[sg_type]


### PR DESCRIPTION
Add support of duration as int as advertised in the doc: http://developer.shotgunsoftware.com/python-api/reference.html?highlight=duration#duration