### PR TITLE
Set include_archived_projects to False by default (RDEV-10205)

### DIFF
--- a/package.py
+++ b/package.py
@@ -1,7 +1,7 @@
 name = "shotgun_api3"
 
 shotgunSoftwareVersion = "3.0.32"
-rodeoVersion = "1.4.0"
+rodeoVersion = "1.4.1"
 version = "-rdo-".join([shotgunSoftwareVersion, rodeoVersion])
 
 authors = ["shotgundev@rodeofx.com"]

--- a/shotgun_api3/shotgun.py
+++ b/shotgun_api3/shotgun.py
@@ -652,7 +652,7 @@ class Shotgun(object):
         return self._call_rpc("info", None, include_auth_params=False)
 
     def find_one(self, entity_type, filters, fields=None, order=None,
-        filter_operator=None, retired_only=False, include_archived_projects=True,
+        filter_operator=None, retired_only=False, include_archived_projects=False,
         additional_filter_presets=None):
         """
         Shortcut for :meth:`~shotgun_api3.Shotgun.find` with ``limit=1`` so it returns a single
@@ -681,7 +681,7 @@ class Shotgun(object):
             retired. There is no option to return both retired and non-retired entities in the
             same query.
         :param bool include_archived_projects: Optional boolean flag to include entities whose projects
-            have been archived. Defaults to ``True``.
+            have been archived. Defaults to ``False``.
         :param additional_filter_presets: Optional list of presets to further filter the result
             set, list has the form::
 
@@ -707,7 +707,7 @@ class Shotgun(object):
 
     def find(self, entity_type, filters, fields=None, order=None,
             filter_operator=None, limit=0, retired_only=False, page=0,
-            include_archived_projects=True, additional_filter_presets=None):
+            include_archived_projects=False, additional_filter_presets=None):
         """
         Find entities matching the given filters.
 
@@ -778,7 +778,7 @@ class Shotgun(object):
             retired. There is no option to return both retired and non-retired entities in the
             same query.
         :param bool include_archived_projects: Optional boolean flag to include entities whose projects
-            have been archived. Defaults to ``True``.
+            have been archived. Defaults to ``False``.
         :param additional_filter_presets: Optional list of presets to further filter the result
             set, list has the form::
 
@@ -910,7 +910,7 @@ class Shotgun(object):
                   summary_fields,
                   filter_operator=None,
                   grouping=None,
-                  include_archived_projects=True):
+                  include_archived_projects=False):
         """
         Summarize field data returned by a query.
 

--- a/tests/tests_unit.py
+++ b/tests/tests_unit.py
@@ -164,9 +164,10 @@ class TestShotgunSummarize(unittest.TestCase):
         result = self.get_call_rpc_params(args, {})
         actual_condition = result['filters']['conditions'][0]
         self.assertEquals(expected_condition, actual_condition)
-        
+
+    @patch('shotgun_api3.shotgun.ServerCapabilities')
     @patch('shotgun_api3.Shotgun._call_rpc')
-    def get_call_rpc_params(self, args, kws, call_rpc):
+    def get_call_rpc_params(self, args, kws, call_rpc, server_caps):
         '''Return params sent to _call_rpc from summarize.'''
         if not args:
             args = [None, [], None]


### PR DESCRIPTION
## Purpose of the PR / What does this do?
Set include_archived_projects to False by default, since we have way …

## Overview of the changes (don't assume any history)
We don't want to query archived projects because it's slow!

## Potential risks of this change, if any.

Pattrick Boucher on https://support.shotgunsoftware.com/hc/en-us/requests/84447?page=2 :

> When you do set include_archived_projects to False we fetch a list of non-archived project ids first (an indexed operation which is very fast) and then fetch your shot records (continuing with our example) where the project is in our list of non-archived project ids. So there is no table join but there is an extra query which is very fast.
> 
> Worst case scenario is your entity query is the same time but you need to add on the extra few milliseconds for the project query.
> Best case scenario is that the complex entity query gets to filter out a lot of data because of the project id filter and the cost of the project query is more than offset by gains in the entity query.