### PR TITLE
Cleanup our fork a little bit

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,0 +1,5 @@
+"""Build"""
+import rdo_package_utils.build
+
+rdo_package_utils.build.buildAndInstall(['shotgun_api3'])
+rdo_package_utils.build.buildAndUploadWheel()

--- a/package.py
+++ b/package.py
@@ -1,19 +1,24 @@
-name = "shotgun_api3"
+# pylint: disable=invalid-name
+"""Shotgun_api3"""
+name = 'shotgun_api3'
 
-shotgunSoftwareVersion = "3.0.32"
-rodeoVersion = "1.6.0"
-version = "-rdo-".join([shotgunSoftwareVersion, rodeoVersion])
+_shotgunSoftwareVersion = '3.0.40'
+_rdoVersion = '1.0.0'
+version = '{0}-rdo-{1}'.format(_shotgunSoftwareVersion, _rdoVersion)
 
-authors = ["shotgundev@rodeofx.com"]
+authors = ['shotgundev@rodeofx.com']
 
-description = """Fork of the python api of shotgun."""
+description = 'Fork of the python api of shotgun.'
 
-requires = ['python-2.4+<3']
+requires = ['python-2.6+<3']
 
-variants = []
+private_build_requires = ['rdo_package_utils']
 
-uuid = "9E411E66-9F35-49BC-AC2E-E9DC6D50D109"
+build_command = 'python {root}/build.py {install}'
+
+uuid = '9E411E66-9F35-49BC-AC2E-E9DC6D50D109'
+
 
 def commands():
-    env.PYTHONPATH.append("{root}/")
-
+    """Commands"""
+    env.PYTHONPATH.append('{root}/')

--- a/rezbuild.py
+++ b/rezbuild.py
@@ -1,3 +1,0 @@
-from __future__ import absolute_import
-import rez.rodeo.packageBuilders
-build = rez.rodeo.packageBuilders.PythonPackageBuilder('shotgun_api3').dispatch

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
-raise DeprecationWarning('Use rez-build to build this package at Rodeo.')
-# following code is kept for compatibility with shotgun software version.
-
 import sys
 from setuptools import setup, find_packages
+
+import package
 
 f = open('README.md')
 readme = f.read().strip()
@@ -17,9 +16,11 @@ if (sys.version_info[0] <= 2) or (sys.version_info[0] == 2 and sys.version_info[
     if 'install' in script_args and '--no-compile' not in script_args:
         script_args.append('--no-compile')
 
+
 setup(
     name='shotgun_api3',
-    version='3.0.40',
+    # The + is part of the python packaging specification. It means it's a local version.
+    version='3.0.40' + '+{0}'.format(package._rdoVersion),
     description='Shotgun Python API ',
     long_description=readme,
     author='Shotgun Software, RodeoFX',
@@ -31,4 +32,5 @@ setup(
     include_package_data=True,
     package_data={'': ['cacerts.txt']},
     zip_safe=False,
+    python_requires='>2.6,<3',
 )


### PR DESCRIPTION
Cleanup our fork a little bit:
* Rewrite the build process to use `rdo_package_utils`
* Cleanup `package.py`
* Add more info in `setup.py`
    * Use rdo version from the `package.py` module
    * Add python compatible versions
    * Use `+` in the version to mark the package as a local version (see https://www.python.org/dev/peps/pep-0440/#local-version-identifiers)