### PR TITLE
[dev] Make mockgun string comparison case insensitive (RDEV-15305)

### DIFF
--- a/package.py
+++ b/package.py
@@ -3,7 +3,7 @@
 name = 'shotgun_api3'
 
 _shotgunSoftwareVersion = '3.1.1'
-_rdoVersion = '1.0.0'
+_rdoVersion = '1.1.0'
 version = '{0}-rdo-{1}'.format(_shotgunSoftwareVersion, _rdoVersion)
 
 authors = ['shotgundev@rodeofx.com']

--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -597,6 +597,13 @@ class Shotgun(object):
             if operator == "is":
                 return lval == rval
         elif field_type == "text":
+            # Shotgun string comparison is case insensitive
+            lval = lval.lower()
+            if isinstance(rval, list):
+                rval = [val.lower() for val in rval]
+            elif isinstance(rval, six.string_types):
+                rval = rval.lower()
+
             if operator == "is":
                 return lval == rval
             elif operator == "is_not":

--- a/tests/test_mockgun.py
+++ b/tests/test_mockgun.py
@@ -205,11 +205,116 @@ class TestTextFieldOperators(TestBaseWithExceptionTests):
         self._mockgun = Mockgun("https://test.shotgunstudio.com", login="user", password="1234")
         self._user = self._mockgun.create("HumanUser", {"login": "user"})
 
+    def test_operator_is(self):
+        """
+        Ensure is operator work.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "is", "user"]])
+        self.assertTrue(item)
+
+    def test_operator_is_case_sensitivity(self):
+        """
+        Ensure is operator is case insensitive.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "is", "USER"]])
+        self.assertTrue(item)
+
+    def test_operator_is_not(self):
+        """
+        Ensure the is_not operator works.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "is_not", "another_user"]])
+        self.assertTrue(item)
+
+    def test_operator_is_not_case_sensitivity(self):
+        """
+        Ensure the is_not operator is case insensitive.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "is_not", "USER"]])
+        self.assertFalse(item)
+
+    def test_operator_in(self):
+        """
+        Ensure the in operator works.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "in", ["user"]]])
+        self.assertTrue(item)
+
+    def test_operator_in_case_sensitivity(self):
+        """
+        Ensure the in operator is case insensitive.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "in", ["USER"]]])
+        self.assertTrue(item)
+
+    def test_operator_not_in(self):
+        """
+        Ensure the not_in operator works.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "not_in", ["foo"]]])
+        self.assertTrue(item)
+
+    def test_operator_not_in_case_sensitivity(self):
+        """
+        Ensure not_in operator is case insensitive.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "not_in", ["USER"]]])
+        self.assertFalse(item)
+
     def test_operator_contains(self):
         """
         Ensures contains operator works.
         """
         item = self._mockgun.find_one("HumanUser", [["login", "contains", "se"]])
+        self.assertTrue(item)
+
+    def test_operator_contains_case_sensitivity(self):
+        """
+        Ensure contains operator is case insensitive.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "contains", "SE"]])
+        self.assertTrue(item)
+
+    def test_operator_not_contains(self):
+        """
+        Ensure not_contains operator works.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "not_contains", "foo"]])
+        self.assertTrue(item)
+
+    def test_operator_not_contains_case_sensitivity(self):
+        """
+        Ensure not_contains operator is case insensitive.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "not_contains", "USER"]])
+        self.assertFalse(item)
+
+    def test_operator_starts_with(self):
+        """
+        Ensure starts_with operator works.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "starts_with", "us"]])
+        self.assertTrue(item)
+
+    def test_operator_starts_with_case_sensitivity(self):
+        """
+        Ensure starts_with operator is case insensitive.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "starts_with", "US"]])
+        self.assertTrue(item)
+
+    def test_operator_ends_with(self):
+        """
+        Ensure ends_with operator works.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "ends_with", "er"]])
+        self.assertTrue(item)
+
+    def test_operator_ends_with_case_sensitivity(self):
+        """
+        Ensure starts_with operator is case insensitive.
+        """
+        item = self._mockgun.find_one("HumanUser", [["login", "ends_with", "ER"]])
         self.assertTrue(item)
 
 


### PR DESCRIPTION
#### Purpose of the PR

This PR ensure that mockgun comparison of text fields are case insensitive.
This is the case for a real Shotgun instance.

After this is approved I will do an official PR upstream.

#### Overview of the changes

* Do lowercase comparison for text fields
* Add unit-tests

#### Type of feedback wanted

Any kind of feedback. 
Is there some other situations where case sensitivity matter that I did not test?

#### Where should the reviewer start looking at?

Diff should be enough

#### Potential risks of this change

Some tests that where using mockgun could start failing (which in my case is what I want).

#### Relationship with other PRs

None
