### PR TITLE
[dev] Fix issues when comparing text fields with None

### DIFF
--- a/package.py
+++ b/package.py
@@ -3,7 +3,7 @@
 name = 'shotgun_api3'
 
 _shotgunSoftwareVersion = '3.1.1'
-_rdoVersion = '1.1.0'
+_rdoVersion = '1.1.1'
 version = '{0}-rdo-{1}'.format(_shotgunSoftwareVersion, _rdoVersion)
 
 authors = ['shotgundev@rodeofx.com']

--- a/shotgun_api3/lib/mockgun/mockgun.py
+++ b/shotgun_api3/lib/mockgun/mockgun.py
@@ -597,12 +597,21 @@ class Shotgun(object):
             if operator == "is":
                 return lval == rval
         elif field_type == "text":
+            # Some operations expect a list but can deal with a single value
+            if operator in ("in", "not_in") and not isinstance(rval, list):
+                rval = [rval]
+
+            # Some operation expect a string but can deal with None
+            elif operator in ("starts_with", "ends_with", "contains", "not_contains"):
+                lval = lval or ''
+                rval = rval or ''
+
             # Shotgun string comparison is case insensitive
-            lval = lval.lower()
+            lval = lval.lower() if lval is not None else None
             if isinstance(rval, list):
-                rval = [val.lower() for val in rval]
-            elif isinstance(rval, six.string_types):
-                rval = rval.lower()
+                rval = [val.lower() if val is not None else None for val in rval]
+            else:
+                rval = rval.lower() if rval is not None else None
 
             if operator == "is":
                 return lval == rval
@@ -613,7 +622,7 @@ class Shotgun(object):
             elif operator == "contains":
                 return rval in lval
             elif operator == "not_contains":
-                return lval not in rval
+                return rval not in lval
             elif operator == "starts_with":
                 return lval.startswith(rval)
             elif operator == "ends_with":

--- a/tests/test_mockgun.py
+++ b/tests/test_mockgun.py
@@ -203,119 +203,175 @@ class TestTextFieldOperators(TestBaseWithExceptionTests):
         Creates test data.
         """
         self._mockgun = Mockgun("https://test.shotgunstudio.com", login="user", password="1234")
-        self._user = self._mockgun.create("HumanUser", {"login": "user"})
+        self._user1 = self._mockgun.create("HumanUser", {"login": "user"})
+        self._user2 = self._mockgun.create("HumanUser", {"login": None})
 
     def test_operator_is(self):
         """
         Ensure is operator work.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "is", "user"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "is", "user"]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
+
+    def test_operator_is_none(self):
+        """
+        Ensure is operator work when used with None.
+        """
+        actual = self._mockgun.find("HumanUser", [["login", "is", None]])
+        expected = [{"type": "HumanUser", "id": self._user2["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_is_case_sensitivity(self):
         """
         Ensure is operator is case insensitive.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "is", "USER"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "is", "USER"]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_is_not(self):
         """
         Ensure the is_not operator works.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "is_not", "another_user"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "is_not", "user"]])
+        expected = [{"type": "HumanUser", "id": self._user2["id"]}]
+        self.assertEqual(expected, actual)
+
+    def test_operator_is_not_none(self):
+        """
+        Ensure the is_not operator works when used with None.
+        """
+        actual = self._mockgun.find("HumanUser", [["login", "is_not", None]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_is_not_case_sensitivity(self):
         """
         Ensure the is_not operator is case insensitive.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "is_not", "USER"]])
-        self.assertFalse(item)
+        actual = self._mockgun.find("HumanUser", [["login", "is_not", "USER"]])
+        expected = [{"type": "HumanUser", "id": self._user2["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_in(self):
         """
         Ensure the in operator works.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "in", ["user"]]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "in", ["user"]]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
+
+    def test_operator_in_none(self):
+        """
+        Ensure the in operator works with a list containing None.
+        """
+        actual = self._mockgun.find("HumanUser", [["login", "in", [None]]])
+        expected = [{"type": "HumanUser", "id": self._user2["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_in_case_sensitivity(self):
         """
         Ensure the in operator is case insensitive.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "in", ["USER"]]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "in", ["USER"]]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_not_in(self):
         """
         Ensure the not_in operator works.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "not_in", ["foo"]]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "not_in", ["foo"]]])
+        expected = [
+            {"type": "HumanUser", "id": self._user1["id"]},
+            {"type": "HumanUser", "id": self._user2["id"]}
+        ]
+        self.assertEqual(expected, actual)
+
+    def test_operator_not_in_none(self):
+        """
+        Ensure the not_not operator works with a list containing None.
+        """
+        actual = self._mockgun.find("HumanUser", [["login", "not_in", [None]]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_not_in_case_sensitivity(self):
         """
-        Ensure not_in operator is case insensitive.
+        Ensure the not_in operator is case insensitive.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "not_in", ["USER"]]])
-        self.assertFalse(item)
+        actual = self._mockgun.find("HumanUser", [["login", "not_in", ["USER"]]])
+        expected = [{"type": "HumanUser", "id": self._user2["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_contains(self):
         """
-        Ensures contains operator works.
+        Ensures the contains operator works.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "contains", "se"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "contains", "se"]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_contains_case_sensitivity(self):
         """
-        Ensure contains operator is case insensitive.
+        Ensure the contains operator is case insensitive.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "contains", "SE"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "contains", "SE"]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_not_contains(self):
         """
-        Ensure not_contains operator works.
+        Ensure the not_contains operator works.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "not_contains", "foo"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "not_contains", "user"]])
+        expected = [
+            {"type": "HumanUser", "id": self._user2["id"]}
+        ]
+        self.assertEqual(expected, actual)
 
     def test_operator_not_contains_case_sensitivity(self):
         """
-        Ensure not_contains operator is case insensitive.
+        Ensure the not_contains operator is case insensitive.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "not_contains", "USER"]])
-        self.assertFalse(item)
+        actual = self._mockgun.find("HumanUser", [["login", "not_contains", "USER"]])
+        expected = [
+            {"type": "HumanUser", "id": self._user2["id"]}
+        ]
+        self.assertEqual(expected, actual)
 
     def test_operator_starts_with(self):
         """
-        Ensure starts_with operator works.
+        Ensure the starts_with operator works.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "starts_with", "us"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "starts_with", "us"]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_starts_with_case_sensitivity(self):
         """
-        Ensure starts_with operator is case insensitive.
+        Ensure the starts_with operator is case insensitive.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "starts_with", "US"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "starts_with", "US"]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_ends_with(self):
         """
-        Ensure ends_with operator works.
+        Ensure the ends_with operator works.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "ends_with", "er"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "ends_with", "er"]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
     def test_operator_ends_with_case_sensitivity(self):
         """
-        Ensure starts_with operator is case insensitive.
+        Ensure the starts_with operator is case insensitive.
         """
-        item = self._mockgun.find_one("HumanUser", [["login", "ends_with", "ER"]])
-        self.assertTrue(item)
+        actual = self._mockgun.find("HumanUser", [["login", "ends_with", "ER"]])
+        expected = [{"type": "HumanUser", "id": self._user1["id"]}]
+        self.assertEqual(expected, actual)
 
 
 class TestDateDatetimeFields(TestBaseWithExceptionTests):


### PR DESCRIPTION
#### Purpose of the PR

This PR fix an issue introduced by https://github.com/rodeofx/python-api/pull/20 when comparing text field with None values. It also fix a bug with the "not_contains" operator. 

After this is approved I will update our upstream PR (https://github.com/shotgunsoftware/python-api/pull/217).

#### Overview of the changes

* Better conforming, aware of `None` values
* Add unit-tests
* Fix "not_contains" not behavior as a real Shotgun instance

#### Type of feedback wanted

Any kind of feedback. 
Is there any cases I did not test? (Note that some operators have no test againts a None value as they crash with a normal shotgun instance, they are: "contains", "not_contains", "starts_with" and "ends_with")

#### Where should the reviewer start looking at?

Diff should be enough

#### Potential risks of this change

Some tests that where using mockgun could start failing (which in my case is what I want).

#### Relationship with other PRs

Continuation of the work in https://github.com/rodeofx/python-api/pull/20
