### PR TITLE
fix: Add missing import in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@
 import sys
 from setuptools import setup, find_packages
 
+import package
+
 f = open("README.md")
 readme = f.read().strip()
 


### PR DESCRIPTION
Among the multiple rebase operations, the import for `package` went missing in the `setup.py` file. This means that the version number with the rdo prefix could not be computed.